### PR TITLE
feat: v2 agent-native harness

### DIFF
--- a/cmd/tidal/main.go
+++ b/cmd/tidal/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/oSEAItic/tidal/internal/config"
 	"github.com/oSEAItic/tidal/internal/runner"
@@ -13,6 +17,7 @@ var (
 	cfgFile    string
 	env        string
 	jsonOutput bool
+	stdinInput bool
 )
 
 func main() {
@@ -25,14 +30,17 @@ func main() {
 	root.PersistentFlags().StringVarP(&cfgFile, "config", "c", "tidal.yaml", "config file path")
 	root.PersistentFlags().StringVarP(&env, "env", "e", "", "environment override (e.g. production)")
 	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "output as structured JSON")
+	root.PersistentFlags().BoolVar(&stdinInput, "stdin", false, "read JSON input from stdin")
 
 	root.AddCommand(initCmd())
 	root.AddCommand(testCmd())
+	root.AddCommand(lintCmd())
 	root.AddCommand(observeCmd())
 	root.AddCommand(shipCmd())
 	root.AddCommand(verifyCmd())
+	root.AddCommand(worktreeCmd())
+	root.AddCommand(gradeCmd())
 	root.AddCommand(statusCmd())
-	root.AddCommand(runLoopCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -48,6 +56,11 @@ func loadConfig() (*config.Config, error) {
 		cfg.ApplyEnv(env)
 	}
 	return cfg, nil
+}
+
+// readStdinJSON reads JSON from stdin into the provided target.
+func readStdinJSON(target interface{}) error {
+	return json.NewDecoder(os.Stdin).Decode(target)
 }
 
 // ── init ──
@@ -77,7 +90,27 @@ func testCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("no test tasks configured")
 			}
-			return runner.Run(tasks, jsonOutput)
+			return runner.Run("test", tasks, jsonOutput)
+		},
+	}
+}
+
+// ── lint ──
+
+func lintCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "lint [name...]",
+		Short: "Run lint/rule checks (all or by name)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			tasks := cfg.LintTasks(args...)
+			if len(tasks) == 0 {
+				return fmt.Errorf("no lint tasks configured")
+			}
+			return runner.Run("lint", tasks, jsonOutput)
 		},
 	}
 }
@@ -87,32 +120,38 @@ func testCmd() *cobra.Command {
 func observeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "observe",
-		Short: "Observe logs, traces, errors",
+		Short: "Observe logs, metrics, traces, CI, issues",
 	}
-	cmd.AddCommand(&cobra.Command{
-		Use:   "logs [name]",
-		Short: "View logs",
-		RunE: func(c *cobra.Command, args []string) error {
-			cfg, err := loadConfig()
-			if err != nil {
-				return err
-			}
-			tasks := cfg.ObserveTasks("logs", args...)
-			return runner.Run(tasks, jsonOutput)
-		},
-	})
-	cmd.AddCommand(&cobra.Command{
-		Use:   "errors",
-		Short: "View errors",
-		RunE: func(c *cobra.Command, args []string) error {
-			cfg, err := loadConfig()
-			if err != nil {
-				return err
-			}
-			tasks := cfg.ObserveTasks("errors", args...)
-			return runner.Run(tasks, jsonOutput)
-		},
-	})
+
+	for _, sub := range []struct {
+		use   string
+		short string
+		kind  string
+	}{
+		{"logs [name]", "View logs", "logs"},
+		{"metrics [name]", "View metrics", "metrics"},
+		{"traces [name]", "View traces", "traces"},
+		{"ci", "View CI status", "ci"},
+		{"issues", "View GitHub issues", "issues"},
+		{"errors", "View errors (deprecated: use issues)", "errors"},
+	} {
+		kind := sub.kind // capture
+		cmd.AddCommand(&cobra.Command{
+			Use:   sub.use,
+			Short: sub.short,
+			RunE: func(c *cobra.Command, args []string) error {
+				cfg, err := loadConfig()
+				if err != nil {
+					return err
+				}
+				tasks := cfg.ObserveTasks(kind, args...)
+				if len(tasks) == 0 {
+					return fmt.Errorf("observe.%s not configured", kind)
+				}
+				return runner.Run("observe", tasks, jsonOutput)
+			},
+		})
+	}
 	return cmd
 }
 
@@ -121,35 +160,72 @@ func observeCmd() *cobra.Command {
 func shipCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ship",
-		Short: "Ship code: PR, deploy",
+		Short: "Ship code: PR, issue, deploy",
 	}
+
 	cmd.AddCommand(&cobra.Command{
-		Use:   "pr",
+		Use:   "pr [title] [body]",
 		Short: "Create a pull request",
 		RunE: func(c *cobra.Command, args []string) error {
 			cfg, err := loadConfig()
 			if err != nil {
 				return err
 			}
-			tasks := cfg.ShipTasks("pr")
-			return runner.Run(tasks, jsonOutput)
+			if stdinInput {
+				var input struct {
+					Title  string `json:"title"`
+					Body   string `json:"body"`
+					Closes []int  `json:"closes"`
+					Branch string `json:"branch"`
+				}
+				if err := readStdinJSON(&input); err != nil {
+					return fmt.Errorf("invalid JSON input: %w", err)
+				}
+				// append closes to body
+				body := input.Body
+				for _, n := range input.Closes {
+					body += fmt.Sprintf("\n\nCloses #%d", n)
+				}
+				args = []string{input.Title, body}
+			}
+			tasks := cfg.ShipTasks("pr", args...)
+			if len(tasks) == 0 {
+				return fmt.Errorf("ship.pr not configured")
+			}
+			return runner.Run("ship", tasks, jsonOutput)
 		},
 	})
+
 	cmd.AddCommand(&cobra.Command{
-		Use:   "issue [title] [body]",
-		Short: "Create a GitHub issue",
+		Use:   "issue [type] [title] [body]",
+		Short: "Create a GitHub issue (--type: feat/bug/chore/doc)",
 		RunE: func(c *cobra.Command, args []string) error {
 			cfg, err := loadConfig()
 			if err != nil {
 				return err
 			}
+			if stdinInput {
+				var input struct {
+					Type  string `json:"type"`
+					Title string `json:"title"`
+					Body  string `json:"body"`
+				}
+				if err := readStdinJSON(&input); err != nil {
+					return fmt.Errorf("invalid JSON input: %w", err)
+				}
+				if input.Type == "" {
+					input.Type = "feat"
+				}
+				args = []string{input.Type, input.Title, input.Body}
+			}
 			tasks := cfg.ShipTasks("issue", args...)
 			if len(tasks) == 0 {
-				return fmt.Errorf("ship.issue not configured in tidal.yaml")
+				return fmt.Errorf("ship.issue not configured")
 			}
-			return runner.Run(tasks, jsonOutput)
+			return runner.Run("ship", tasks, jsonOutput)
 		},
 	})
+
 	cmd.AddCommand(&cobra.Command{
 		Use:   "deploy [env]",
 		Short: "Deploy to environment",
@@ -163,9 +239,13 @@ func shipCmd() *cobra.Command {
 				target = args[0]
 			}
 			tasks := cfg.ShipTasks("deploy", target)
-			return runner.Run(tasks, jsonOutput)
+			if len(tasks) == 0 {
+				return fmt.Errorf("ship.deploy.%s not configured", target)
+			}
+			return runner.Run("ship", tasks, jsonOutput)
 		},
 	})
+
 	return cmd
 }
 
@@ -181,7 +261,216 @@ func verifyCmd() *cobra.Command {
 				return err
 			}
 			tasks := cfg.VerifyTasks(args...)
-			return runner.Run(tasks, jsonOutput)
+			if len(tasks) == 0 {
+				return fmt.Errorf("no verify tasks configured")
+			}
+			return runner.Run("verify", tasks, jsonOutput)
+		},
+	}
+}
+
+// ── worktree ──
+
+func worktreeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "worktree",
+		Short: "Manage isolated git worktrees",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "create <name>",
+		Short: "Create an isolated worktree for parallel work",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			if cfg.Worktree == nil {
+				return fmt.Errorf("worktree not configured in tidal.yaml")
+			}
+			name := args[0]
+			dir := cfg.Worktree.Dir
+			if dir == "" {
+				dir = "/tmp/tidal-worktrees"
+			}
+			wtPath := filepath.Join(dir, name)
+			branch := "tidal/" + name
+
+			// git worktree add
+			gitCmd := exec.Command("git", "worktree", "add", "-b", branch, wtPath)
+			out, err := gitCmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("git worktree add failed: %s\n%s", err, string(out))
+			}
+
+			// run setup command if configured
+			if cfg.Worktree.Setup != "" {
+				setupCmd := exec.Command("sh", "-c", cfg.Worktree.Setup)
+				setupCmd.Dir = wtPath
+				if setupOut, err := setupCmd.CombinedOutput(); err != nil {
+					fmt.Fprintf(os.Stderr, "setup warning: %s\n%s", err, string(setupOut))
+				}
+			}
+
+			result := runner.TaskResult{
+				Name:   name,
+				Status: "pass",
+				Structured: map[string]string{
+					"path":   wtPath,
+					"branch": branch,
+				},
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(runner.Envelope{
+					Command: "worktree",
+					Tasks:   []runner.TaskResult{result},
+				})
+			} else {
+				fmt.Printf("created worktree: %s → %s (branch: %s)\n", name, wtPath, branch)
+			}
+			return nil
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List active worktrees",
+		RunE: func(c *cobra.Command, args []string) error {
+			out, err := exec.Command("git", "worktree", "list", "--porcelain").CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("git worktree list failed: %s", err)
+			}
+
+			type wtInfo struct {
+				Path   string `json:"path"`
+				Branch string `json:"branch"`
+			}
+			var worktrees []wtInfo
+			var current wtInfo
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.HasPrefix(line, "worktree ") {
+					if current.Path != "" {
+						worktrees = append(worktrees, current)
+					}
+					current = wtInfo{Path: strings.TrimPrefix(line, "worktree ")}
+				} else if strings.HasPrefix(line, "branch ") {
+					current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+				}
+			}
+			if current.Path != "" {
+				worktrees = append(worktrees, current)
+			}
+
+			if jsonOutput {
+				var results []runner.TaskResult
+				for _, wt := range worktrees {
+					results = append(results, runner.TaskResult{
+						Name:   filepath.Base(wt.Path),
+						Status: "pass",
+						Structured: map[string]string{
+							"path":   wt.Path,
+							"branch": wt.Branch,
+						},
+					})
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(runner.Envelope{
+					Command: "worktree",
+					Tasks:   results,
+				})
+			} else {
+				fmt.Printf("%-20s %-40s %s\n", "NAME", "PATH", "BRANCH")
+				fmt.Println(strings.Repeat("─", 70))
+				for _, wt := range worktrees {
+					fmt.Printf("%-20s %-40s %s\n", filepath.Base(wt.Path), wt.Path, wt.Branch)
+				}
+			}
+			return nil
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "destroy <name>",
+		Short: "Remove a worktree and its branch",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			name := args[0]
+			dir := "/tmp/tidal-worktrees"
+			if cfg.Worktree != nil && cfg.Worktree.Dir != "" {
+				dir = cfg.Worktree.Dir
+			}
+			wtPath := filepath.Join(dir, name)
+			branch := "tidal/" + name
+
+			// run cleanup if configured
+			if cfg.Worktree != nil && cfg.Worktree.Cleanup != "" {
+				cleanupCmd := exec.Command("sh", "-c", cfg.Worktree.Cleanup)
+				cleanupCmd.Dir = wtPath
+				if out, err := cleanupCmd.CombinedOutput(); err != nil {
+					fmt.Fprintf(os.Stderr, "cleanup warning: %s\n%s", err, string(out))
+				}
+			}
+
+			// git worktree remove
+			rmCmd := exec.Command("git", "worktree", "remove", wtPath, "--force")
+			if out, err := rmCmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("git worktree remove failed: %s\n%s", err, string(out))
+			}
+
+			// delete branch
+			brCmd := exec.Command("git", "branch", "-D", branch)
+			_ = brCmd.Run() // best effort
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(runner.Envelope{
+					Command: "worktree",
+					Tasks: []runner.TaskResult{{
+						Name:   name,
+						Status: "pass",
+						Structured: map[string]string{
+							"path":   wtPath,
+							"branch": branch,
+							"action": "destroyed",
+						},
+					}},
+				})
+			} else {
+				fmt.Printf("destroyed worktree: %s\n", name)
+			}
+			return nil
+		},
+	})
+
+	return cmd
+}
+
+// ── grade ──
+
+func gradeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "grade [name...]",
+		Short: "Run quality scoring tasks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			tasks := cfg.GradeTasks(args...)
+			if len(tasks) == 0 {
+				return fmt.Errorf("no grade tasks configured")
+			}
+			return runner.Run("grade", tasks, jsonOutput)
 		},
 	}
 }
@@ -197,69 +486,64 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if jsonOutput {
+				status := map[string]interface{}{
+					"command": "status",
+					"name":    cfg.Name,
+					"lang":    cfg.Lang,
+					"capabilities": map[string]interface{}{
+						"test":        capInfo(len(cfg.Test) > 0, mapKeys(cfg.Test)),
+						"lint":        capInfo(len(cfg.Lint) > 0, mapKeys(cfg.Lint)),
+						"observe":     capInfo(len(cfg.Observe.Logs) > 0 || cfg.Observe.Issues != nil || cfg.Observe.CI != nil, nil),
+						"ship:pr":     capInfo(cfg.Ship.PR != nil, nil),
+						"ship:issue":  capInfo(cfg.Ship.Issue != nil, issueTypes(cfg.Ship.Issue)),
+						"ship:deploy": capInfo(len(cfg.Ship.Deploy) > 0, mapKeysTask(cfg.Ship.Deploy)),
+						"verify":      capInfo(cfg.Verify.Health != nil || len(cfg.Verify.Smoke) > 0, nil),
+						"worktree":    capInfo(cfg.Worktree != nil, nil),
+						"grade":       capInfo(len(cfg.Grade) > 0, mapKeys(cfg.Grade)),
+					},
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(status)
+			}
 			cfg.PrintStatus()
 			return nil
 		},
 	}
 }
 
-// ── run-loop ──
-
-func runLoopCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "run-loop",
-		Short: "Full autonomous loop: observe → test → ship → verify",
-		Long:  "Runs configured phases sequentially. Stops on first failure unless --force is set.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := loadConfig()
-			if err != nil {
-				return err
-			}
-
-			steps := cfg.RunLoopSteps()
-			if len(steps) == 0 {
-				return fmt.Errorf("no phases configured — run tidal init first")
-			}
-
-			fmt.Printf("run-loop: %s\n\n", joinArrow(steps))
-
-			for _, step := range steps {
-				fmt.Printf("── %s ──\n", step)
-				var tasks []runner.Task
-				switch step {
-				case "observe":
-					tasks = cfg.ObserveTasks("errors")
-					tasks = append(tasks, cfg.ObserveTasks("logs")...)
-				case "test":
-					tasks = cfg.TestTasks()
-				case "ship":
-					tasks = cfg.ShipTasks("pr")
-				case "verify":
-					tasks = cfg.VerifyTasks()
-				}
-				if len(tasks) == 0 {
-					fmt.Printf("  (skipped — no tasks)\n\n")
-					continue
-				}
-				if err := runner.Run(tasks, jsonOutput); err != nil {
-					return fmt.Errorf("run-loop stopped at %s: %w", step, err)
-				}
-				fmt.Println()
-			}
-
-			fmt.Println("run-loop: complete ✓")
-			return nil
-		},
+func capInfo(ready bool, details interface{}) map[string]interface{} {
+	m := map[string]interface{}{"ready": ready}
+	if details != nil {
+		m["tasks"] = details
 	}
+	return m
 }
 
-func joinArrow(ss []string) string {
-	result := ""
-	for i, s := range ss {
-		if i > 0 {
-			result += " → "
-		}
-		result += s
+func mapKeys(m map[string]config.Task) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
 	}
-	return result
+	return keys
+}
+
+func mapKeysTask(m map[string]*config.Task) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func issueTypes(ic *config.IssueConfig) []string {
+	if ic == nil {
+		return nil
+	}
+	var types []string
+	for t := range ic.Types {
+		types = append(types, t)
+	}
+	return types
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,21 +11,28 @@ import (
 
 // Config represents a tidal.yaml file.
 type Config struct {
-	Harness string            `yaml:"harness"`
-	Name    string            `yaml:"name"`
-	Lang    string            `yaml:"lang"`
-	Observe ObserveBlock       `yaml:"observe"`
-	Test    map[string]Task    `yaml:"test"`
-	Ship    ShipBlock          `yaml:"ship"`
-	Verify  VerifyBlock        `yaml:"verify"`
-	Vars    map[string]string  `yaml:"vars"`
-	Envs    map[string]EnvOver `yaml:"envs"`
+	Harness  string            `yaml:"harness"`
+	Name     string            `yaml:"name"`
+	Lang     string            `yaml:"lang"`
+	Observe  ObserveBlock      `yaml:"observe"`
+	Test     map[string]Task   `yaml:"test"`
+	Lint     map[string]Task   `yaml:"lint"`
+	Ship     ShipBlock         `yaml:"ship"`
+	Verify   VerifyBlock       `yaml:"verify"`
+	Worktree *WorktreeConfig   `yaml:"worktree"`
+	Grade    map[string]Task   `yaml:"grade"`
+	Vars     map[string]string `yaml:"vars"`
+	Envs     map[string]EnvOver `yaml:"envs"`
 }
 
 type ObserveBlock struct {
-	Logs   []NamedTask `yaml:"logs"`
-	Traces *Task       `yaml:"traces"`
-	Errors *Task       `yaml:"errors"`
+	Logs    []NamedTask `yaml:"logs"`
+	Metrics []NamedTask `yaml:"metrics"`
+	Traces  []NamedTask `yaml:"traces"`
+	CI      *Task       `yaml:"ci"`
+	Issues  *Task       `yaml:"issues"`
+	// deprecated: use Issues instead
+	Errors *Task `yaml:"errors"`
 }
 
 type NamedTask struct {
@@ -45,13 +52,19 @@ type Task struct {
 }
 
 type ShipBlock struct {
-	PR     *PRConfig          `yaml:"pr"`
-	Issue  *IssueConfig       `yaml:"issue"`
-	Deploy map[string]*Task   `yaml:"deploy"`
+	PR     *PRConfig        `yaml:"pr"`
+	Issue  *IssueConfig     `yaml:"issue"`
+	Deploy map[string]*Task `yaml:"deploy"`
 }
 
 type IssueConfig struct {
-	Repo   string   `yaml:"repo"`
+	Repo  string                       `yaml:"repo"`
+	Types map[string]IssueTypeConfig   `yaml:"types"`
+	// deprecated v1 field
+	Labels []string `yaml:"labels"`
+}
+
+type IssueTypeConfig struct {
 	Labels []string `yaml:"labels"`
 }
 
@@ -66,6 +79,12 @@ type VerifyBlock struct {
 	Health   *Task       `yaml:"health"`
 	Smoke    []NamedTask `yaml:"smoke"`
 	Rollback *Task       `yaml:"rollback"`
+}
+
+type WorktreeConfig struct {
+	Dir     string `yaml:"dir"`
+	Setup   string `yaml:"setup"`
+	Cleanup string `yaml:"cleanup"`
 }
 
 type EnvOver struct {
@@ -84,6 +103,17 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Vars == nil {
 		cfg.Vars = make(map[string]string)
+	}
+	// backward compat: observe.errors → observe.issues
+	if cfg.Observe.Issues == nil && cfg.Observe.Errors != nil {
+		cfg.Observe.Issues = cfg.Observe.Errors
+		fmt.Fprintln(os.Stderr, "warning: observe.errors is deprecated, use observe.issues")
+	}
+	// backward compat: ship.issue.labels → ship.issue.types.bug
+	if cfg.Ship.Issue != nil && len(cfg.Ship.Issue.Labels) > 0 && len(cfg.Ship.Issue.Types) == 0 {
+		cfg.Ship.Issue.Types = map[string]IssueTypeConfig{
+			"bug": {Labels: cfg.Ship.Issue.Labels},
+		}
 	}
 	return &cfg, nil
 }
@@ -109,8 +139,23 @@ func (c *Config) expand(s string) string {
 
 // TestTasks returns runner tasks for the test block.
 func (c *Config) TestTasks(names ...string) []runner.Task {
+	return c.blockTasks(c.Test, names...)
+}
+
+// LintTasks returns runner tasks for the lint block.
+func (c *Config) LintTasks(names ...string) []runner.Task {
+	return c.blockTasks(c.Lint, names...)
+}
+
+// GradeTasks returns runner tasks for the grade block.
+func (c *Config) GradeTasks(names ...string) []runner.Task {
+	return c.blockTasks(c.Grade, names...)
+}
+
+// blockTasks is a generic helper for map[string]Task blocks.
+func (c *Config) blockTasks(block map[string]Task, names ...string) []runner.Task {
 	var tasks []runner.Task
-	for name, t := range c.Test {
+	for name, t := range block {
 		if len(names) > 0 && !contains(names, name) {
 			continue
 		}
@@ -138,10 +183,40 @@ func (c *Config) ObserveTasks(kind string, names ...string) []runner.Task {
 			}
 			tasks = append(tasks, runner.Task{Name: "logs:" + l.Name, Cmd: c.expand(cmd)})
 		}
+	case "metrics":
+		for _, m := range c.Observe.Metrics {
+			if len(names) > 0 && !contains(names, m.Name) {
+				continue
+			}
+			cmd := m.Cmd
+			if cmd == "" && m.API != "" {
+				cmd = "curl -sf " + m.API
+			}
+			tasks = append(tasks, runner.Task{Name: "metrics:" + m.Name, Cmd: c.expand(cmd)})
+		}
+	case "traces":
+		for _, t := range c.Observe.Traces {
+			if len(names) > 0 && !contains(names, t.Name) {
+				continue
+			}
+			cmd := t.Cmd
+			if cmd == "" && t.API != "" {
+				cmd = "curl -sf " + t.API
+			}
+			tasks = append(tasks, runner.Task{Name: "traces:" + t.Name, Cmd: c.expand(cmd)})
+		}
+	case "ci":
+		if c.Observe.CI != nil {
+			tasks = append(tasks, runner.Task{Name: "ci", Cmd: c.expand(c.Observe.CI.Cmd)})
+		}
+	case "issues":
+		if c.Observe.Issues != nil {
+			tasks = append(tasks, runner.Task{Name: "issues", Cmd: c.expand(c.Observe.Issues.Cmd)})
+		}
 	case "errors":
-		if c.Observe.Errors != nil {
-			cmd := c.Observe.Errors.Cmd
-			tasks = append(tasks, runner.Task{Name: "errors", Cmd: c.expand(cmd)})
+		// backward compat
+		if c.Observe.Issues != nil {
+			tasks = append(tasks, runner.Task{Name: "issues", Cmd: c.expand(c.Observe.Issues.Cmd)})
 		}
 	}
 	return tasks
@@ -154,17 +229,27 @@ func (c *Config) ShipTasks(kind string, args ...string) []runner.Task {
 	case "pr":
 		if c.Ship.PR != nil {
 			cmd := fmt.Sprintf("gh pr create --base %s", c.Ship.PR.Base)
+			if len(args) >= 1 && args[0] != "" {
+				cmd += fmt.Sprintf(" --title %q", args[0])
+			}
+			if len(args) >= 2 && args[1] != "" {
+				cmd += fmt.Sprintf(" --body %q", args[1])
+			}
 			tasks = append(tasks, runner.Task{Name: "pr", Cmd: c.expand(cmd)})
 		}
 	case "issue":
 		if c.Ship.Issue != nil {
+			issueType := "feat"
 			title := "auto-reported issue"
 			body := ""
 			if len(args) >= 1 {
-				title = args[0]
+				issueType = args[0]
 			}
 			if len(args) >= 2 {
-				body = args[1]
+				title = args[1]
+			}
+			if len(args) >= 3 {
+				body = args[2]
 			}
 			repo := c.Ship.Issue.Repo
 			if repo == "" {
@@ -172,8 +257,11 @@ func (c *Config) ShipTasks(kind string, args ...string) []runner.Task {
 			}
 			cmd := fmt.Sprintf("gh issue create --repo %s --title %q --body %q",
 				repo, title, body)
-			for _, l := range c.Ship.Issue.Labels {
-				cmd += fmt.Sprintf(" --label %q", l)
+			// apply labels from type config
+			if tc, ok := c.Ship.Issue.Types[issueType]; ok {
+				for _, l := range tc.Labels {
+					cmd += fmt.Sprintf(" --label %q", l)
+				}
 			}
 			tasks = append(tasks, runner.Task{Name: "issue", Cmd: c.expand(cmd)})
 		}
@@ -191,24 +279,6 @@ func (c *Config) ShipTasks(kind string, args ...string) []runner.Task {
 		}
 	}
 	return tasks
-}
-
-// RunLoopSteps returns the ordered phases for a full autonomous loop.
-func (c *Config) RunLoopSteps() []string {
-	var steps []string
-	if len(c.Observe.Logs) > 0 || c.Observe.Errors != nil {
-		steps = append(steps, "observe")
-	}
-	if len(c.Test) > 0 {
-		steps = append(steps, "test")
-	}
-	if c.Ship.PR != nil {
-		steps = append(steps, "ship")
-	}
-	if c.Verify.Health != nil || len(c.Verify.Smoke) > 0 {
-		steps = append(steps, "verify")
-	}
-	return steps
 }
 
 // VerifyTasks returns runner tasks for verification.
@@ -245,11 +315,14 @@ func (c *Config) PrintStatus() {
 
 	fmt.Println("Capabilities:")
 	section("test", len(c.Test) > 0)
-	section("observe", len(c.Observe.Logs) > 0 || c.Observe.Errors != nil)
+	section("lint", len(c.Lint) > 0)
+	section("observe", len(c.Observe.Logs) > 0 || c.Observe.Issues != nil || c.Observe.CI != nil)
 	section("ship:pr", c.Ship.PR != nil)
 	section("ship:issue", c.Ship.Issue != nil)
 	section("ship:deploy", len(c.Ship.Deploy) > 0)
 	section("verify", c.Verify.Health != nil || len(c.Verify.Smoke) > 0)
+	section("worktree", c.Worktree != nil)
+	section("grade", len(c.Grade) > 0)
 }
 
 func contains(ss []string, s string) bool {

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-const yamlTemplate = `harness: v1
+const yamlTemplate = `harness: v2
 name: my-project
 lang: go
 
@@ -14,18 +14,26 @@ observe:
   logs:
     - name: app
       cmd: "tail -100 /var/log/app.log"
-  errors:
-    cmd: "gh issue list --label bug --state open"
+    - name: git
+      cmd: "git log --oneline -20"
+  ci:
+    cmd: "gh run list --repo {{repo}} --limit 5"
+  issues:
+    cmd: "gh issue list --repo {{repo}} --state open"
 
 # ── test: validate changes ──
 test:
   build:
     cmd: "go build ./cmd/..."
-  lint:
-    cmd: "golangci-lint run"
   unit:
     cmd: "go test ./... -short"
     timeout: 120
+
+# ── lint: check rules and constraints ──
+lint:
+  vet:
+    cmd: "go vet ./..."
+  # add your linters here
 
 # ── ship: deliver ──
 ship:
@@ -33,6 +41,15 @@ ship:
     base: main
     prefix: "tidal/"
     auto_test: true
+  issue:
+    repo: "{{repo}}"
+    types:
+      feat:
+        labels: [enhancement]
+      bug:
+        labels: [bug]
+      chore:
+        labels: [chore]
   deploy:
     staging:
       cmd: "echo 'deploy to staging'"
@@ -44,17 +61,27 @@ ship:
 # ── verify: confirm results ──
 verify:
   health:
-    cmd: "curl -sf http://localhost:8080/health"
+    cmd: "curl -sf {{base_url}}/health"
     retries: 3
     interval: 10
   smoke:
     - name: ping
-      cmd: "curl -sf http://localhost:8080/api/v1/ping"
-  rollback:
-    cmd: "echo 'rollback not configured'"
+      cmd: "curl -sf {{base_url}}/api/v1/ping"
+
+# ── worktree: isolated execution ──
+worktree:
+  dir: "/tmp/tidal-worktrees"
+  setup: ""
+  cleanup: ""
+
+# ── grade: quality scoring ──
+grade:
+  test_count:
+    cmd: "go test ./... -v -short 2>&1 | grep -c PASS"
 
 # ── variables (use {{var_name}} in commands) ──
 vars:
+  repo: "owner/repo"
   service: my-project
   base_url: "http://localhost:8080"
   env: staging

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,18 +19,33 @@ type Task struct {
 	Confirm bool // require user confirmation
 }
 
-// Result holds the outcome of running a task.
-type Result struct {
-	Name   string `json:"name"`
-	Status string `json:"status"` // "pass" or "fail"
-	TimeMs int64  `json:"time_ms"`
-	Output string `json:"output,omitempty"`
-	Error  string `json:"error,omitempty"`
+// TaskResult holds the outcome of running a single task.
+type TaskResult struct {
+	Name       string      `json:"name"`
+	Status     string      `json:"status"` // "pass", "fail", "skip"
+	TimeMs     int64       `json:"time_ms"`
+	Output     string      `json:"output,omitempty"`     // raw output (for humans)
+	Error      string      `json:"error,omitempty"`      // error message if failed
+	Structured interface{} `json:"structured,omitempty"` // structured data (for agents)
 }
 
-// Run executes tasks sequentially and prints results.
-func Run(tasks []Task, jsonOut bool) error {
-	var results []Result
+// Envelope is the unified JSON output for all tidal commands.
+type Envelope struct {
+	Command string       `json:"command"`
+	Tasks   []TaskResult `json:"tasks"`
+	Summary *Summary     `json:"summary,omitempty"`
+}
+
+// Summary provides counts for quick agent parsing.
+type Summary struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+}
+
+// Run executes tasks and prints results.
+func Run(command string, tasks []Task, jsonOut bool) error {
+	var results []TaskResult
 	var failed bool
 
 	for _, t := range tasks {
@@ -42,7 +57,7 @@ func Run(tasks []Task, jsonOut bool) error {
 	}
 
 	if jsonOut {
-		printJSON(results)
+		printJSON(command, results)
 	} else {
 		printTable(results)
 	}
@@ -53,7 +68,12 @@ func Run(tasks []Task, jsonOut bool) error {
 	return nil
 }
 
-func execute(t Task) Result {
+// RunSingle executes a single task and returns its result directly.
+func RunSingle(t Task) TaskResult {
+	return execute(t)
+}
+
+func execute(t Task) TaskResult {
 	start := time.Now()
 
 	timeout := time.Duration(t.Timeout) * time.Second
@@ -68,7 +88,7 @@ func execute(t Task) Result {
 	out, err := cmd.CombinedOutput()
 	elapsed := time.Since(start).Milliseconds()
 
-	r := Result{
+	r := TaskResult{
 		Name:   t.Name,
 		TimeMs: elapsed,
 		Output: strings.TrimSpace(string(out)),
@@ -84,7 +104,7 @@ func execute(t Task) Result {
 	return r
 }
 
-func printTable(results []Result) {
+func printTable(results []TaskResult) {
 	fmt.Printf("%-16s %-8s %-10s %s\n", "TASK", "STATUS", "TIME", "DETAIL")
 	fmt.Println(strings.Repeat("─", 60))
 
@@ -92,6 +112,8 @@ func printTable(results []Result) {
 		icon := "✅"
 		if r.Status == "fail" {
 			icon = "❌"
+		} else if r.Status == "skip" {
+			icon = "⏭️"
 		}
 		detail := r.Error
 		if len(detail) > 40 {
@@ -101,10 +123,30 @@ func printTable(results []Result) {
 	}
 }
 
-func printJSON(results []Result) {
+func printJSON(command string, results []TaskResult) {
+	passed := 0
+	failed := 0
+	for _, r := range results {
+		if r.Status == "pass" {
+			passed++
+		} else if r.Status == "fail" {
+			failed++
+		}
+	}
+
+	env := Envelope{
+		Command: command,
+		Tasks:   results,
+		Summary: &Summary{
+			Total:  len(results),
+			Passed: passed,
+			Failed: failed,
+		},
+	}
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(results)
+	_ = enc.Encode(env)
 }
 
 func fmtMs(ms int64) string {

--- a/tidal.yaml
+++ b/tidal.yaml
@@ -1,29 +1,32 @@
-harness: v1
+harness: v2
 name: tidal
 lang: go
 
-# ---- observe: see what's happening ----
+# ── observe ──
 observe:
   logs:
     - name: git
       cmd: "git log --oneline -20"
     - name: build
       cmd: "go build ./cmd/tidal 2>&1 || true"
-    - name: ci
-      cmd: "gh run list --repo {{repo}} --limit 5"
-  errors:
-    cmd: "gh issue list --repo {{repo}} --label bug --state open"
+  ci:
+    cmd: "gh run list --repo {{repo}} --limit 5"
+  issues:
+    cmd: "gh issue list --repo {{repo}} --state open"
 
-# ---- test: validate changes ----
+# ── test ──
 test:
   build:
     cmd: "go build -o /dev/null ./cmd/tidal"
-  vet:
-    cmd: "go vet ./..."
   unit:
     cmd: "go test ./... -short"
 
-# ---- ship: deliver ----
+# ── lint ──
+lint:
+  vet:
+    cmd: "go vet ./..."
+
+# ── ship ──
 ship:
   pr:
     base: main
@@ -36,22 +39,40 @@ ship:
       {{test_output}}
   issue:
     repo: "{{repo}}"
-    labels:
-      - bug
+    types:
+      feat:
+        labels: [enhancement]
+      bug:
+        labels: [bug]
+      chore:
+        labels: [chore]
+      doc:
+        labels: [documentation]
 
-# ---- verify: confirm results ----
+# ── verify ──
 verify:
   health:
     cmd: "go build -o /dev/null ./cmd/tidal && echo 'binary builds OK'"
   smoke:
     - name: "cli help"
       cmd: "go run ./cmd/tidal --help > /dev/null"
-    - name: "cli init dry"
+    - name: "cli status"
       cmd: "go run ./cmd/tidal status"
-    - name: "ci status"
-      cmd: "gh run list --repo {{repo}} --limit 1 --json conclusion -q '.[0].conclusion' | grep -q success && echo 'CI green' || echo 'CI not green'"
 
-# ---- vars ----
+# ── worktree ──
+worktree:
+  dir: "/tmp/tidal-worktrees"
+  setup: "go mod download"
+  cleanup: ""
+
+# ── grade ──
+grade:
+  test_count:
+    cmd: "go test ./... -v -short 2>&1 | grep -c PASS || echo 0"
+  file_count:
+    cmd: "find . -name '*.go' -not -path './vendor/*' | wc -l | tr -d ' '"
+
+# ── vars ──
 vars:
   repo: "oSEAItic/tidal"
   summary: ""


### PR DESCRIPTION
## Summary\n\n- **Unified JSON output**: all commands return  envelope\n- **JSON input**:  flag for ship issue/pr (no more shell escaping)\n- **New blocks**: , ,  as top-level capabilities\n- **observe.issues**: replaces observe.errors, sees all issue types\n- **observe.ci**: dedicated CI status field\n- **ship.issue types**:  with per-type labels\n- **status --json**: full capability introspection for agents\n- **Backward compat**: v1 configs auto-migrate with deprecation warnings\n\n## Dog-fooding\n\nThis PR was developed using tidal itself:\n- Issues created via \n-  tested via \n-  tested for isolation\n- All verify/test/lint/grade passing\n\nCloses #2, closes #3, closes #4, closes #5, closes #6, closes #7\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCloses #2\n\nCloses #3\n\nCloses #4\n\nCloses #5\n\nCloses #6\n\nCloses #7