### PR TITLE
feat: autoharness — topology, paths, external, history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # IDE
 .idea/
 .vscode/
+
+# History
+.tidal/

--- a/cmd/tidal/main.go
+++ b/cmd/tidal/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/oSEAItic/tidal/internal/config"
+	"github.com/oSEAItic/tidal/internal/history"
 	"github.com/oSEAItic/tidal/internal/runner"
 	"github.com/spf13/cobra"
 )
@@ -41,6 +42,8 @@ func main() {
 	root.AddCommand(reviewCmd())
 	root.AddCommand(worktreeCmd())
 	root.AddCommand(gradeCmd())
+	root.AddCommand(topologyCmd())
+	root.AddCommand(historyCmd())
 	root.AddCommand(statusCmd())
 
 	if err := root.Execute(); err != nil {
@@ -62,6 +65,15 @@ func loadConfig() (*config.Config, error) {
 // readStdinJSON reads JSON from stdin into the provided target.
 func readStdinJSON(target interface{}) error {
 	return json.NewDecoder(os.Stdin).Decode(target)
+}
+
+// runAndRecord runs tasks, prints output, and appends to history.
+func runAndRecord(cfg *config.Config, command string, tasks []runner.Task) error {
+	env, err := runner.Run(command, tasks, jsonOutput)
+	if env != nil && cfg.History != nil {
+		_ = history.Append(cfg.HistoryDir(), *env)
+	}
+	return err
 }
 
 // ── init ──
@@ -91,7 +103,7 @@ func testCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("no test tasks configured")
 			}
-			return runner.Run("test", tasks, jsonOutput)
+			return runAndRecord(cfg, "test", tasks)
 		},
 	}
 }
@@ -111,7 +123,7 @@ func lintCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("no lint tasks configured")
 			}
-			return runner.Run("lint", tasks, jsonOutput)
+			return runAndRecord(cfg, "lint", tasks)
 		},
 	}
 }
@@ -131,7 +143,7 @@ func reviewCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("no review tasks configured")
 			}
-			return runner.Run("review", tasks, jsonOutput)
+			return runAndRecord(cfg, "review", tasks)
 		},
 	}
 }
@@ -169,7 +181,7 @@ func observeCmd() *cobra.Command {
 				if len(tasks) == 0 {
 					return fmt.Errorf("observe.%s not configured", kind)
 				}
-				return runner.Run("observe", tasks, jsonOutput)
+				return runAndRecord(cfg, "observe", tasks)
 			},
 		})
 	}
@@ -213,7 +225,7 @@ func shipCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("ship.pr not configured")
 			}
-			return runner.Run("ship", tasks, jsonOutput)
+			return runAndRecord(cfg, "ship", tasks)
 		},
 	})
 
@@ -243,7 +255,7 @@ func shipCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("ship.issue not configured")
 			}
-			return runner.Run("ship", tasks, jsonOutput)
+			return runAndRecord(cfg, "ship", tasks)
 		},
 	})
 
@@ -263,7 +275,7 @@ func shipCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("ship.deploy.%s not configured", target)
 			}
-			return runner.Run("ship", tasks, jsonOutput)
+			return runAndRecord(cfg, "ship", tasks)
 		},
 	})
 
@@ -285,7 +297,7 @@ func verifyCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("no verify tasks configured")
 			}
-			return runner.Run("verify", tasks, jsonOutput)
+			return runAndRecord(cfg, "verify", tasks)
 		},
 	}
 }
@@ -491,7 +503,7 @@ func gradeCmd() *cobra.Command {
 			if len(tasks) == 0 {
 				return fmt.Errorf("no grade tasks configured")
 			}
-			return runner.Run("grade", tasks, jsonOutput)
+			return runAndRecord(cfg, "grade", tasks)
 		},
 	}
 }
@@ -523,6 +535,10 @@ func statusCmd() *cobra.Command {
 						"verify":      capInfo(cfg.Verify.Health != nil || len(cfg.Verify.Smoke) > 0, nil),
 						"worktree":    capInfo(cfg.Worktree != nil, nil),
 						"grade":       capInfo(len(cfg.Grade) > 0, mapKeys(cfg.Grade)),
+						"topology":    capInfo(cfg.Topology != nil && len(cfg.Topology.Services) > 0, nil),
+						"paths":       capInfo(len(cfg.Paths) > 0, nil),
+						"external":    capInfo(len(cfg.External) > 0, nil),
+						"history":     capInfo(cfg.History != nil, nil),
 					},
 				}
 				enc := json.NewEncoder(os.Stdout)
@@ -568,4 +584,117 @@ func issueTypes(ic *config.IssueConfig) []string {
 		types = append(types, t)
 	}
 	return types
+}
+
+// ── topology ──
+
+func topologyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "topology",
+		Short: "Show project service topology",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			if cfg.Topology == nil || len(cfg.Topology.Services) == 0 {
+				return fmt.Errorf("topology not configured in tidal.yaml")
+			}
+
+			if jsonOutput {
+				out := map[string]interface{}{
+					"command":  "topology",
+					"services": cfg.Topology.Services,
+					"paths":    cfg.Paths,
+					"external": cfg.External,
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+
+			fmt.Println("Services:")
+			for _, s := range cfg.Topology.Services {
+				detail := s.Lang
+				if detail == "" {
+					detail = s.Type
+				}
+				deps := ""
+				if len(s.DependsOn) > 0 {
+					deps = " → depends on: " + strings.Join(s.DependsOn, ", ")
+				}
+				port := ""
+				if s.Port > 0 {
+					port = fmt.Sprintf(" :%d", s.Port)
+				}
+				fmt.Printf("  %-16s %-8s %-20s%s%s\n", s.Name, detail, s.Path, port, deps)
+			}
+
+			if len(cfg.Paths) > 0 {
+				fmt.Println("\nPaths:")
+				for k, v := range cfg.Paths {
+					fmt.Printf("  %-16s %s\n", k, v)
+				}
+			}
+
+			if len(cfg.External) > 0 {
+				fmt.Println("\nExternal:")
+				for k, v := range cfg.External {
+					fmt.Printf("  %-16s %s\n", k, v)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// ── history ──
+
+func historyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "history [limit]",
+		Short: "Show run history",
+		RunE: func(c *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			limit := 20
+			if len(args) > 0 {
+				fmt.Sscanf(args[0], "%d", &limit)
+			}
+
+			records, err := history.Read(cfg.HistoryDir(), limit)
+			if err != nil {
+				return err
+			}
+			if len(records) == 0 {
+				fmt.Println("no history yet")
+				return nil
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(records)
+			}
+
+			fmt.Printf("%-22s %-12s %s\n", "TIME", "COMMAND", "RESULT")
+			fmt.Println(strings.Repeat("─", 50))
+			for _, r := range records {
+				result := "—"
+				if r.Summary != nil {
+					if r.Summary.Failed > 0 {
+						result = fmt.Sprintf("❌ %d/%d failed", r.Summary.Failed, r.Summary.Total)
+					} else {
+						result = fmt.Sprintf("✅ %d passed", r.Summary.Passed)
+					}
+				}
+				fmt.Printf("%-22s %-12s %s\n", r.Timestamp[:19], r.Command, result)
+			}
+			return nil
+		},
+	}
+	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,8 +22,31 @@ type Config struct {
 	Review   map[string]Task   `yaml:"review"`
 	Worktree *WorktreeConfig   `yaml:"worktree"`
 	Grade    map[string]Task   `yaml:"grade"`
+	Topology *TopologyBlock    `yaml:"topology"`
+	Paths    map[string]string `yaml:"paths"`
+	External map[string]string `yaml:"external"`
+	History  *HistoryConfig    `yaml:"history"`
 	Vars     map[string]string `yaml:"vars"`
 	Envs     map[string]EnvOver `yaml:"envs"`
+}
+
+// TopologyBlock describes the project's service architecture.
+type TopologyBlock struct {
+	Services []ServiceInfo `yaml:"services"`
+}
+
+type ServiceInfo struct {
+	Name      string   `yaml:"name"`
+	Lang      string   `yaml:"lang,omitempty"`
+	Type      string   `yaml:"type,omitempty"` // e.g. "postgres", "redis"
+	Path      string   `yaml:"path,omitempty"`
+	Port      int      `yaml:"port,omitempty"`
+	Cmd       string   `yaml:"cmd,omitempty"`
+	DependsOn []string `yaml:"depends_on,omitempty"`
+}
+
+type HistoryConfig struct {
+	Dir string `yaml:"dir"` // default ".tidal/"
 }
 
 type ObserveBlock struct {
@@ -329,6 +352,18 @@ func (c *Config) PrintStatus() {
 	section("verify", c.Verify.Health != nil || len(c.Verify.Smoke) > 0)
 	section("worktree", c.Worktree != nil)
 	section("grade", len(c.Grade) > 0)
+	section("topology", c.Topology != nil && len(c.Topology.Services) > 0)
+	section("paths", len(c.Paths) > 0)
+	section("external", len(c.External) > 0)
+	section("history", c.History != nil)
+}
+
+// HistoryDir returns the directory for run history, defaulting to ".tidal/".
+func (c *Config) HistoryDir() string {
+	if c.History != nil && c.History.Dir != "" {
+		return c.History.Dir
+	}
+	return ".tidal"
 }
 
 func contains(ss []string, s string) bool {

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,73 @@
+package history
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/oSEAItic/tidal/internal/runner"
+)
+
+// Record is a single entry in the history log.
+type Record struct {
+	Timestamp string          `json:"ts"`
+	Command   string          `json:"command"`
+	Summary   *runner.Summary `json:"summary"`
+}
+
+// Append writes a run result to the history file.
+func Append(dir string, env runner.Envelope) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	path := filepath.Join(dir, "history.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	rec := Record{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Command:   env.Command,
+		Summary:   env.Summary,
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(f, "%s\n", data)
+	return err
+}
+
+// Read returns the last N records from the history file.
+func Read(dir string, limit int) ([]Record, error) {
+	path := filepath.Join(dir, "history.jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var all []Record
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var r Record
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			continue
+		}
+		all = append(all, r)
+	}
+
+	if limit > 0 && len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, scanner.Err()
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -44,8 +44,8 @@ type Summary struct {
 	Failed int `json:"failed"`
 }
 
-// Run executes tasks and prints results.
-func Run(command string, tasks []Task, jsonOut bool) error {
+// Run executes tasks, prints results, and returns the envelope.
+func Run(command string, tasks []Task, jsonOut bool) (*Envelope, error) {
 	var results []TaskResult
 	var failed bool
 
@@ -57,16 +57,41 @@ func Run(command string, tasks []Task, jsonOut bool) error {
 		}
 	}
 
+	env := buildEnvelope(command, results)
+
 	if jsonOut {
-		printJSON(command, results)
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(env)
 	} else {
 		printTable(results)
 	}
 
 	if failed {
-		return fmt.Errorf("one or more tasks failed")
+		return &env, fmt.Errorf("one or more tasks failed")
 	}
-	return nil
+	return &env, nil
+}
+
+func buildEnvelope(command string, results []TaskResult) Envelope {
+	passed := 0
+	failed := 0
+	for _, r := range results {
+		if r.Status == "pass" {
+			passed++
+		} else if r.Status == "fail" {
+			failed++
+		}
+	}
+	return Envelope{
+		Command: command,
+		Tasks:   results,
+		Summary: &Summary{
+			Total:  len(results),
+			Passed: passed,
+			Failed: failed,
+		},
+	}
 }
 
 // RunSingle executes a single task and returns its result directly.
@@ -130,31 +155,6 @@ func printTable(results []TaskResult) {
 	}
 }
 
-func printJSON(command string, results []TaskResult) {
-	passed := 0
-	failed := 0
-	for _, r := range results {
-		if r.Status == "pass" {
-			passed++
-		} else if r.Status == "fail" {
-			failed++
-		}
-	}
-
-	env := Envelope{
-		Command: command,
-		Tasks:   results,
-		Summary: &Summary{
-			Total:  len(results),
-			Passed: passed,
-			Failed: failed,
-		},
-	}
-
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(env)
-}
 
 func fmtMs(ms int64) string {
 	if ms < 1000 {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -60,9 +60,12 @@ func TestRunPass(t *testing.T) {
 		{Name: "a", Cmd: "echo a"},
 		{Name: "b", Cmd: "echo b"},
 	}
-	err := Run("test", tasks, false)
+	env, err := Run("test", tasks, false)
 	if err != nil {
 		t.Errorf("Run returned error: %v", err)
+	}
+	if env.Summary.Passed != 2 {
+		t.Errorf("Summary.Passed = %d, want 2", env.Summary.Passed)
 	}
 }
 
@@ -71,8 +74,11 @@ func TestRunFail(t *testing.T) {
 		{Name: "ok", Cmd: "echo ok"},
 		{Name: "bad", Cmd: "exit 1"},
 	}
-	err := Run("test", tasks, false)
+	env, err := Run("test", tasks, false)
 	if err == nil {
 		t.Error("Run should return error when task fails")
+	}
+	if env.Summary.Failed != 1 {
+		t.Errorf("Summary.Failed = %d, want 1", env.Summary.Failed)
 	}
 }

--- a/tidal.yaml
+++ b/tidal.yaml
@@ -85,6 +85,33 @@ grade:
   file_count:
     cmd: "find . -name '*.go' -not -path './vendor/*' | wc -l | tr -d ' '"
 
+# ── topology: what is this project ──
+topology:
+  services:
+    - name: tidal-cli
+      lang: go
+      path: ./cmd/tidal
+      depends_on: []
+
+# ── paths: where things are ──
+paths:
+  cli_entry: "./cmd/tidal/main.go"
+  config_pkg: "./internal/config/"
+  runner_pkg: "./internal/runner/"
+  history_pkg: "./internal/history/"
+  docs: "./doc/"
+  schema_design: "./doc/schema-v2-design.md"
+
+# ── external: outside dependencies ──
+external:
+  ci: "GitHub Actions"
+  issues: "GitHub Issues"
+  repo: "github.com/oSEAItic/tidal"
+
+# ── history: run recording ──
+history:
+  dir: ".tidal"
+
 # ── vars ──
 vars:
   repo: "oSEAItic/tidal"


### PR DESCRIPTION
## Summary

tidal.yaml now records not just HOW (commands) but also:
- **WHAT** — `topology` block: services, languages, ports, dependencies
- **WHERE** — `paths` block: key file locations
- **WHO** — `external` block: outside dependencies
- **HISTORY** — auto-records every tidal run to `.tidal/history.jsonl`

## New commands

| Command | What it does |
|---------|-------------|
| `tidal topology --json` | Show project service architecture |
| `tidal history --json` | Show run history with pass/fail trends |

## Dog-fooding

Full tidal lifecycle used:
```
tidal grade             → test_count=22, found no issues
tidal ship issue        → #15
tidal worktree create   → /tmp/tidal-worktrees/autoharness
tidal test              → 1 fail (runner_test), fixed, 22 pass
tidal review            → clean
tidal history           → shows fail→pass progression
tidal ship pr           → this PR
```

14/14 capabilities now ready (only ship:deploy not configured).

Closes #15

Closes #15