### PR TITLE
feat: zero-friction — CI gen + npx + GitHub Action + MCP server

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,45 @@
+name: "Tidal Harness"
+description: "Run tidal autoharness checks on your repo"
+branding:
+  icon: "anchor"
+  color: "blue"
+
+inputs:
+  commands:
+    description: "Space-separated tidal commands to run (default: test lint review grade)"
+    required: false
+    default: "test lint review grade"
+  json:
+    description: "Output as JSON"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install tidal
+      shell: bash
+      run: |
+        curl -sf https://raw.githubusercontent.com/oSEAItic/tidal/main/install.sh | sh
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Check tidal.yaml
+      shell: bash
+      run: |
+        if [ ! -f tidal.yaml ]; then
+          echo "No tidal.yaml found. Running tidal init..."
+          tidal init
+        fi
+
+    - name: Run tidal commands
+      shell: bash
+      run: |
+        FLAG=""
+        if [ "${{ inputs.json }}" = "true" ]; then
+          FLAG="--json"
+        fi
+        for cmd in ${{ inputs.commands }}; do
+          echo "::group::tidal $cmd"
+          tidal $cmd $FLAG || true
+          echo "::endgroup::"
+        done

--- a/cmd/tidal/main.go
+++ b/cmd/tidal/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oSEAItic/tidal/internal/detect"
 	"github.com/oSEAItic/tidal/internal/history"
 	"github.com/oSEAItic/tidal/internal/runner"
+	"github.com/oSEAItic/tidal/mcp"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,7 @@ func main() {
 	root.AddCommand(topologyCmd())
 	root.AddCommand(historyCmd())
 	root.AddCommand(statusCmd())
+	root.AddCommand(mcpCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -101,11 +103,24 @@ func initCmd() *cobra.Command {
 				return err
 			}
 
+			// generate CI workflow if .github/workflows doesn't have tidal.yml
+			ciDir := filepath.Join(dir, ".github", "workflows")
+			ciPath := filepath.Join(ciDir, "tidal.yml")
+			ciGenerated := false
+			if _, err := os.Stat(ciPath); os.IsNotExist(err) {
+				_ = os.MkdirAll(ciDir, 0755)
+				if err := os.WriteFile(ciPath, []byte(detect.GenerateCIWorkflow()), 0644); err == nil {
+					ciGenerated = true
+				}
+			}
+			_ = ciGenerated // used in output below
+
 			if jsonOutput {
 				out := map[string]interface{}{
-					"command":  "init",
-					"name":     result.Name,
-					"lang":     result.Lang,
+					"command": "init",
+					"name":    result.Name,
+					"lang":    result.Lang,
+					"files":   []string{"tidal.yaml"},
 					"detected": map[string]interface{}{
 						"test":     len(result.Test),
 						"lint":     len(result.Lint),
@@ -115,6 +130,10 @@ func initCmd() *cobra.Command {
 						"external": len(result.External),
 						"repo":     result.Repo,
 					},
+				}
+				if ciGenerated {
+					out["files"] = []string{"tidal.yaml", ".github/workflows/tidal.yml"}
+					out["ci"] = "github-actions"
 				}
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
@@ -627,6 +646,19 @@ func issueTypes(ic *config.IssueConfig) []string {
 		types = append(types, t)
 	}
 	return types
+}
+
+// ── mcp ──
+
+func mcpCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "mcp",
+		Short:  "Run as MCP server (JSON-RPC over stdio)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mcp.Serve()
+		},
+	}
 }
 
 // ── topology ──

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+REPO="oSEAItic/tidal"
+INSTALL_DIR="${TIDAL_INSTALL_DIR:-$HOME/.local/bin}"
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+esac
+
+ASSET="tidal-${OS}-${ARCH}"
+URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+
+mkdir -p "$INSTALL_DIR"
+
+echo "Installing tidal to ${INSTALL_DIR}..."
+
+if command -v curl >/dev/null 2>&1; then
+  curl -sfL "$URL" -o "${INSTALL_DIR}/tidal"
+elif command -v wget >/dev/null 2>&1; then
+  wget -qO "${INSTALL_DIR}/tidal" "$URL"
+else
+  echo "Error: curl or wget required" >&2
+  exit 1
+fi
+
+chmod +x "${INSTALL_DIR}/tidal"
+
+if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
+  echo ""
+  echo "Add to your PATH:"
+  echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+fi
+
+echo "tidal installed successfully: ${INSTALL_DIR}/tidal"

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -396,6 +396,43 @@ func (r Result) ToYAML() string {
 	return b.String()
 }
 
+// GenerateCIWorkflow returns a GitHub Actions workflow that runs tidal.
+func GenerateCIWorkflow() string {
+	return `name: tidal
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tidal
+        run: |
+          curl -sf https://raw.githubusercontent.com/oSEAItic/tidal/main/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Test
+        run: tidal test --json
+
+      - name: Lint
+        run: tidal lint --json
+        continue-on-error: true
+
+      - name: Review
+        run: tidal review --json
+        continue-on-error: true
+
+      - name: Grade
+        run: tidal grade --json
+        continue-on-error: true
+`
+}
+
 // helpers
 
 func exists(dir, name string) bool {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1,0 +1,253 @@
+// Package mcp provides a Model Context Protocol server for tidal.
+//
+// This allows AI agents (Claude Code, etc.) to use tidal natively
+// without shelling out to the CLI.
+//
+// Usage in Claude Code settings:
+//
+//	{
+//	  "mcpServers": {
+//	    "tidal": {
+//	      "command": "tidal",
+//	      "args": ["mcp"]
+//	    }
+//	  }
+//	}
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/oSEAItic/tidal/internal/config"
+	"github.com/oSEAItic/tidal/internal/runner"
+)
+
+// Tool describes an MCP tool.
+type Tool struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	InputSchema JSONSchema `json:"inputSchema"`
+}
+
+type JSONSchema struct {
+	Type       string                    `json:"type"`
+	Properties map[string]SchemaProperty `json:"properties,omitempty"`
+}
+
+type SchemaProperty struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+}
+
+// Request is a JSON-RPC request.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC response.
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *RPCError   `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+var tools = []Tool{
+	{
+		Name:        "tidal_status",
+		Description: "Show configured capabilities for this repo",
+		InputSchema: JSONSchema{Type: "object"},
+	},
+	{
+		Name:        "tidal_test",
+		Description: "Run test tasks and return structured results",
+		InputSchema: JSONSchema{
+			Type: "object",
+			Properties: map[string]SchemaProperty{
+				"name": {Type: "string", Description: "Specific test to run (optional)"},
+			},
+		},
+	},
+	{
+		Name:        "tidal_lint",
+		Description: "Run lint/rule checks and return structured results",
+		InputSchema: JSONSchema{
+			Type: "object",
+			Properties: map[string]SchemaProperty{
+				"name": {Type: "string", Description: "Specific lint to run (optional)"},
+			},
+		},
+	},
+	{
+		Name:        "tidal_review",
+		Description: "Analyze current changes before shipping (diff, secrets, TODOs)",
+		InputSchema: JSONSchema{Type: "object"},
+	},
+	{
+		Name:        "tidal_observe",
+		Description: "Observe logs, issues, or CI status",
+		InputSchema: JSONSchema{
+			Type: "object",
+			Properties: map[string]SchemaProperty{
+				"kind": {Type: "string", Description: "What to observe: logs, issues, ci"},
+			},
+		},
+	},
+	{
+		Name:        "tidal_grade",
+		Description: "Run quality scoring tasks and return metrics",
+		InputSchema: JSONSchema{Type: "object"},
+	},
+	{
+		Name:        "tidal_topology",
+		Description: "Show project service topology, paths, and external dependencies",
+		InputSchema: JSONSchema{Type: "object"},
+	},
+}
+
+// Serve runs the MCP server on stdin/stdout (JSON-RPC over stdio).
+func Serve() error {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var req Request
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+		resp := handle(req)
+		data, _ := json.Marshal(resp)
+		fmt.Fprintf(os.Stdout, "%s\n", data)
+	}
+	return scanner.Err()
+}
+
+func handle(req Request) Response {
+	switch req.Method {
+	case "initialize":
+		return Response{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]interface{}{
+				"protocolVersion": "2024-11-05",
+				"capabilities":   map[string]interface{}{"tools": map[string]bool{}},
+				"serverInfo":     map[string]string{"name": "tidal", "version": "0.1.0"},
+			},
+		}
+
+	case "tools/list":
+		return Response{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{"tools": tools}}
+
+	case "tools/call":
+		var params struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		json.Unmarshal(req.Params, &params)
+		result, err := callTool(params.Name, params.Arguments)
+		if err != nil {
+			return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -1, Message: err.Error()}}
+		}
+		return Response{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{
+			"content": []map[string]interface{}{
+				{"type": "text", "text": result},
+			},
+		}}
+
+	default:
+		return Response{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{}}
+	}
+}
+
+func callTool(name string, args map[string]interface{}) (string, error) {
+	cfg, err := config.Load("tidal.yaml")
+	if err != nil {
+		return "", fmt.Errorf("cannot load tidal.yaml: %w", err)
+	}
+
+	var tasks []runner.Task
+	command := ""
+
+	switch name {
+	case "tidal_status":
+		// return status as JSON directly
+		status := map[string]interface{}{
+			"name": cfg.Name, "lang": cfg.Lang,
+			"test": len(cfg.Test) > 0, "lint": len(cfg.Lint) > 0,
+			"review": len(cfg.Review) > 0, "grade": len(cfg.Grade) > 0,
+		}
+		data, _ := json.MarshalIndent(status, "", "  ")
+		return string(data), nil
+
+	case "tidal_test":
+		command = "test"
+		if n, ok := args["name"].(string); ok && n != "" {
+			tasks = cfg.TestTasks(n)
+		} else {
+			tasks = cfg.TestTasks()
+		}
+
+	case "tidal_lint":
+		command = "lint"
+		if n, ok := args["name"].(string); ok && n != "" {
+			tasks = cfg.LintTasks(n)
+		} else {
+			tasks = cfg.LintTasks()
+		}
+
+	case "tidal_review":
+		command = "review"
+		tasks = cfg.ReviewTasks()
+
+	case "tidal_observe":
+		command = "observe"
+		kind := "issues"
+		if k, ok := args["kind"].(string); ok && k != "" {
+			kind = k
+		}
+		tasks = cfg.ObserveTasks(kind)
+
+	case "tidal_grade":
+		command = "grade"
+		tasks = cfg.GradeTasks()
+
+	case "tidal_topology":
+		if cfg.Topology != nil {
+			out := map[string]interface{}{
+				"services": cfg.Topology.Services,
+				"paths":    cfg.Paths,
+				"external": cfg.External,
+			}
+			data, _ := json.MarshalIndent(out, "", "  ")
+			return string(data), nil
+		}
+		return "{}", nil
+
+	default:
+		return "", fmt.Errorf("unknown tool: %s", name)
+	}
+
+	if len(tasks) == 0 {
+		return fmt.Sprintf("{\"error\": \"%s not configured\"}", command), nil
+	}
+
+	// run tasks and capture results
+	var results []runner.TaskResult
+	for _, t := range tasks {
+		results = append(results, runner.RunSingle(t))
+	}
+	data, _ := json.MarshalIndent(results, "", "  ")
+	return string(data), nil
+}

--- a/npm/bin/tidal.js
+++ b/npm/bin/tidal.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { execFileSync } = require("child_process");
+const path = require("path");
+const os = require("os");
+
+const ext = os.platform() === "win32" ? ".exe" : "";
+const bin = path.join(__dirname, "tidal" + ext);
+
+try {
+  execFileSync(bin, process.argv.slice(2), { stdio: "inherit" });
+} catch (e) {
+  process.exit(e.status || 1);
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+
+const REPO = "oSEAItic/tidal";
+const BIN_NAME = "tidal";
+
+function getPlatform() {
+  const platform = os.platform();
+  const arch = os.arch();
+  const goos = platform === "win32" ? "windows" : platform;
+  const goarch = arch === "x64" ? "amd64" : arch === "arm64" ? "arm64" : arch;
+  const ext = platform === "win32" ? ".exe" : "";
+  return { goos, goarch, ext };
+}
+
+function install() {
+  const { goos, goarch, ext } = getPlatform();
+  const binDir = path.join(__dirname, "bin");
+  const binPath = path.join(binDir, BIN_NAME + ext);
+
+  if (fs.existsSync(binPath)) return;
+
+  fs.mkdirSync(binDir, { recursive: true });
+
+  // Try downloading pre-built binary from GitHub releases
+  const asset = `tidal-${goos}-${goarch}${ext}`;
+  const url = `https://github.com/${REPO}/releases/latest/download/${asset}`;
+
+  try {
+    console.log(`Downloading tidal from ${url}...`);
+    execSync(`curl -sfL "${url}" -o "${binPath}" && chmod +x "${binPath}"`, {
+      stdio: "inherit",
+    });
+    return;
+  } catch {
+    // fallback: build from source if Go is available
+  }
+
+  try {
+    console.log("No pre-built binary. Building from source...");
+    execSync(
+      `go install github.com/${REPO}/cmd/tidal@latest`,
+      { stdio: "inherit" }
+    );
+    const gobin =
+      execSync("go env GOPATH").toString().trim() + "/bin/tidal" + ext;
+    if (fs.existsSync(gobin)) {
+      fs.copyFileSync(gobin, binPath);
+      fs.chmodSync(binPath, 0o755);
+      return;
+    }
+  } catch {
+    // go not available
+  }
+
+  console.error(
+    "Could not install tidal. Install Go and run: go install github.com/oSEAItic/tidal/cmd/tidal@latest"
+  );
+  process.exit(1);
+}
+
+install();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tidal-harness",
+  "version": "0.1.0",
+  "description": "Universal dev harness for AI agents and humans",
+  "bin": {
+    "tidal": "./bin/tidal.js"
+  },
+  "scripts": {
+    "postinstall": "node ./install.js"
+  },
+  "keywords": ["ai", "agent", "harness", "devops", "testing", "autoharness"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oSEAItic/tidal.git"
+  }
+}


### PR DESCRIPTION
## Zero friction for vibe coders and agents

### What changed

| Feature | What it does | Who benefits |
|---------|-------------|-------------|
| `tidal init` generates `.github/workflows/tidal.yml` | CI runs tidal on every push/PR | Everyone |
| `npm/` package | `npx tidal init` without Go | Vibe coders |
| `action/` GitHub Action | One-line CI integration | Teams |
| `mcp/` MCP server | `tidal mcp` — agents call tidal natively | AI agents |
| `install.sh` | `curl \| sh` installer | CI environments |

### How it works now

**Vibe coder:**
```bash
npx tidal init    # generates tidal.yaml + CI workflow
git push          # CI automatically runs tidal test/lint/review/grade
```

**Agent (via MCP):**
```json
// Claude Code settings
{"mcpServers":{"tidal":{"command":"tidal","args":["mcp"]}}}

// Agent calls tidal_test → gets structured JSON
// Agent calls tidal_topology → knows project structure
// 7 tools: status, test, lint, review, observe, grade, topology
```

**CI:**
```yaml
steps:
  - uses: oSEAItic/tidal-action@v1
```

Closes #21

Closes #21